### PR TITLE
Make external fonts work again

### DIFF
--- a/lib/pdf/external_font.ex
+++ b/lib/pdf/external_font.ex
@@ -2,8 +2,23 @@ defmodule Pdf.ExternalFont do
   @moduledoc false
   defstruct name: nil,
             font_file: nil,
-            metrics: nil,
-            dictionary: nil
+            dictionary: nil,
+            full_name: nil,
+            family_name: nil,
+            weight: nil,
+            italic_angle: nil,
+            encoding: nil,
+            first_char: 0,
+            last_char: 255,
+            ascender: nil,
+            descender: nil,
+            cap_height: 0,
+            x_height: nil,
+            fixed_pitch: false,
+            bbox: nil,
+            widths: [],
+            glyphs: %{},
+            kern_pairs: []
 
   import Pdf.Utils
   alias Pdf.Font.Metrics
@@ -32,9 +47,24 @@ defmodule Pdf.ExternalFont do
 
     %__MODULE__{
       name: font_metrics.name,
-      metrics: %{font_metrics | last_char: last_char, widths: widths},
       font_file: font_file,
-      dictionary: font_file_dictionary(part1, part2, part3)
+      dictionary: font_file_dictionary(part1, part2, part3),
+      full_name: font_metrics.full_name,
+      family_name: font_metrics.family_name,
+      weight: font_metrics.weight,
+      italic_angle: font_metrics.italic_angle,
+      encoding: font_metrics.encoding,
+      first_char: font_metrics.first_char,
+      last_char: last_char,
+      ascender: font_metrics.ascender,
+      descender: font_metrics.descender,
+      cap_height: font_metrics.cap_height || 0,
+      x_height: font_metrics.x_height,
+      fixed_pitch: font_metrics.fixed_pitch,
+      bbox: font_metrics.bbox,
+      widths: widths,
+      glyphs: font_metrics.glyphs,
+      kern_pairs: font_metrics.kern_pairs
     }
   end
 
@@ -43,10 +73,10 @@ defmodule Pdf.ExternalFont do
     |> Dictionary.put("Type", n("Font"))
     |> Dictionary.put("Subtype", n("Type1"))
     |> Dictionary.put("Name", n("F#{id}"))
-    |> Dictionary.put("BaseFont", n(font.metrics.name))
-    |> Dictionary.put("FirstChar", font.metrics.first_char)
-    |> Dictionary.put("LastChar", font.metrics.last_char)
-    |> Dictionary.put("Widths", Array.new(Enum.map(font.metrics.widths, &to_string/1)))
+    |> Dictionary.put("BaseFont", n(font.name))
+    |> Dictionary.put("FirstChar", font.first_char)
+    |> Dictionary.put("LastChar", font.last_char)
+    |> Dictionary.put("Widths", Array.new(Enum.map(font.widths, &to_string/1)))
     |> Dictionary.put("Encoding", n("WinAnsiEncoding"))
     |> Dictionary.put("FontDescriptor", desc_id)
   end
@@ -57,12 +87,13 @@ defmodule Pdf.ExternalFont do
     Dictionary.new()
     |> Dictionary.put("Type", n("FontDescriptor"))
     |> Dictionary.put("Flags", flags)
-    |> Dictionary.put("FontName", n(font.metrics.name))
+    |> Dictionary.put("FontName", n(font.name))
     |> Dictionary.put("StemV", 100)
-    |> Dictionary.put("Ascent", font.metrics.ascender / 1)
-    |> Dictionary.put("Descent", font.metrics.descender / 1)
-    |> Dictionary.put("FontBBox", Array.new(Tuple.to_list(font.metrics.bbox)))
-    |> Dictionary.put("ItalicAngle", font.metrics.italic_angle)
+    |> Dictionary.put("Ascent", font.ascender / 1)
+    |> Dictionary.put("Descent", font.descender / 1)
+    |> Dictionary.put("FontBBox", Array.new(Tuple.to_list(font.bbox)))
+    |> Dictionary.put("ItalicAngle", font.italic_angle)
+    |> Dictionary.put("CapHeight", font.cap_height / 1)
     |> Dictionary.put("FontFile", ff_id)
   end
 
@@ -78,6 +109,53 @@ defmodule Pdf.ExternalFont do
     # size_of(font.dictionary) + byte_size(font.font_file) + byte_size(@stream_start <> @stream_end)
     byte_size(to_iolist(font) |> Enum.join())
   end
+
+  @doc """
+  Returns the width of the specific character
+
+  Examples:
+
+    iex> ExternalFont.width(font, "A")
+    123
+  """
+  def width(font, <<char_code::integer>> = str) when is_binary(str) do
+    width(font, char_code)
+  end
+
+  def width(font, char_code) do
+    Pdf.Encoding.WinAnsi.characters()
+    |> Enum.find(fn {_, char, _} -> char == char_code end)
+    |> case do
+      nil ->
+        0
+
+      {_, _, name} ->
+        case font.glyphs[name] do
+          nil ->
+            0
+
+          %{width: width} ->
+            width
+        end
+    end
+  end
+
+  def kern_text(_font, ""), do: [""]
+
+  def kern_text(font, <<first::integer, second::integer, rest::binary>>) do
+    font.kern_pairs
+    |> Enum.find(fn {f, s, _amount} -> f == first && s == second end)
+    |> case do
+      {f, _s, amount} ->
+        [<<f>>, -amount | kern_text(font, <<second::integer, rest::binary>>)]
+
+      nil ->
+        [head | tail] = kern_text(font, <<second::integer, rest::binary>>)
+        [<<first::integer, head::binary>> | tail]
+    end
+  end
+
+  def kern_text(_font, <<_::integer>> = char), do: [char]
 
   def to_iolist(%__MODULE__{} = font) do
     Pdf.Export.to_iolist([

--- a/lib/pdf/font/metrics.ex
+++ b/lib/pdf/font/metrics.ex
@@ -40,8 +40,9 @@ defmodule Pdf.Font.Metrics do
   def process_line(<<"FullName ", data::binary>>, metrics), do: %{metrics | full_name: data}
   def process_line(<<"FamilyName ", data::binary>>, metrics), do: %{metrics | family_name: data}
 
-  def process_line(<<"Weight ", data::binary>>, metrics),
-    do: %{metrics | weight: String.to_atom(String.downcase(data))}
+  def process_line(<<"Weight ", data::binary>>, metrics) do
+    %{metrics | weight: String.to_atom(String.downcase(data))}
+  end
 
   def process_line(<<"ItalicAngle ", data::binary>>, metrics) do
     case Float.parse(data) do

--- a/lib/pdf/page.ex
+++ b/lib/pdf/page.ex
@@ -18,7 +18,7 @@ defmodule Pdf.Page do
   defdelegate table!(page, data, xy, wh, opts), to: Pdf.Table
 
   import Pdf.Utils
-  alias Pdf.{Image, Fonts, Stream, Text}
+  alias Pdf.{Image, Fonts, Stream, Text, Font}
 
   def new(opts \\ [size: :a4]), do: init(opts, %__MODULE__{stream: Stream.new()})
 
@@ -224,7 +224,7 @@ defmodule Pdf.Page do
 
         font =
           if Enum.any?([:bold, :italic], &Keyword.has_key?(opts, &1)) do
-            Fonts.get_font(fonts, font.family_name, Keyword.take(opts, [:bold, :italic]))
+            Fonts.get_font(fonts, font, Keyword.take(opts, [:bold, :italic]))
           else
             Fonts.get_font(fonts, font.name, [])
           end
@@ -240,7 +240,7 @@ defmodule Pdf.Page do
         x_height = font.module.x_height * font_size / 1000
         line_gap = (font_size - (ascender + descender)) / 2
 
-        width = font.module.text_width(text, font_size, opts)
+        width = Font.text_width(font.module, text, font_size, opts)
 
         {text, width,
          Keyword.merge(

--- a/lib/pdf/text.ex
+++ b/lib/pdf/text.ex
@@ -32,7 +32,7 @@ defmodule Pdf.Text do
     |> Regex.scan(string, capture: :all_but_first)
     |> Enum.flat_map(& &1)
     |> Enum.reject(&(&1 == ""))
-    |> Enum.map(&{&1, font.text_width(&1, font_size, opts), opts})
+    |> Enum.map(&{&1, Pdf.Font.text_width(font, &1, font_size, opts), opts})
   end
 
   def chunk_attributed_text(attributed_text, opts) do

--- a/test/pdf/external_font_test.exs
+++ b/test/pdf/external_font_test.exs
@@ -2,10 +2,11 @@ defmodule Pdf.ExternalFontTest do
   use ExUnit.Case, asyn: true
 
   alias Pdf.ExternalFont
+  alias Pdf.Font
   alias Pdf.Size
   alias Pdf.Export
 
-  @font "Verdana-Bold"
+  @font "Verdana"
 
   setup do
     %ExternalFont{} = font = ExternalFont.load("test/fonts/#{@font}.afm")
@@ -13,9 +14,7 @@ defmodule Pdf.ExternalFontTest do
   end
 
   test "font metrics", %{font: font} do
-    metrics = font.metrics
-
-    assert metrics.name == @font
+    assert font.name == @font
   end
 
   test "font file", %{font: font} do
@@ -38,6 +37,23 @@ defmodule Pdf.ExternalFontTest do
       result = Export.to_iolist(font) |> Enum.join()
 
       assert Size.size_of(font) == byte_size(result)
+    end
+  end
+
+  test "widths", %{font: font} do
+    assert 256 == length(font.widths)
+  end
+
+  test "width/2", %{font: font} do
+    assert 684 == ExternalFont.width(font, "A")
+  end
+
+  describe "text_width/3" do
+    test "It calculates the width of a line of text", %{font: font} do
+      assert Font.text_width(font, "VA") == 1368
+      assert Font.text_width(font, "VA", 10) == 13.68
+      assert Font.text_width(font, "VA", kerning: true) == 1339
+      assert Font.text_width(font, "VA", 10, kerning: true) == 13.39
     end
   end
 end

--- a/test/pdf/font_test.exs
+++ b/test/pdf/font_test.exs
@@ -1,21 +1,29 @@
 defmodule Pdf.FontTest do
   use ExUnit.Case, async: true
+  alias Pdf.Font
 
   describe "text_width/3" do
     test "It calculates the width of a line of text" do
       font = Pdf.Font.Helvetica
-      assert font.text_width("VA") == 1334
-      assert font.text_width("VA", 10) == 13.34
-      assert font.text_width("VA", kerning: true) == 1254
-      assert font.text_width("VA", 10, kerning: true) == 12.54
+      assert Font.text_width(font, "VA") == 1334
+      assert Font.text_width(font, "VA", 10) == 13.34
+      assert Font.text_width(font, "VA", kerning: true) == 1254
+      assert Font.text_width(font, "VA", 10, kerning: true) == 12.54
     end
 
     test "It calculates the width of a blank string" do
       font = Pdf.Font.Helvetica
-      assert font.text_width("") == 0
-      assert font.text_width("", 10) == 0
-      assert font.text_width("", kerning: true) == 0
-      assert font.text_width("", 10, kerning: true) == 0
+      assert Font.text_width(font, "") == 0
+      assert Font.text_width(font, "", 10) == 0
+      assert Font.text_width(font, "", kerning: true) == 0
+      assert Font.text_width(font, "", 10, kerning: true) == 0
     end
+  end
+
+  describe "lookup" do
+    assert Pdf.Font.Helvetica == Pdf.Font.lookup("Helvetica")
+    assert Pdf.Font.HelveticaBold == Pdf.Font.lookup("Helvetica", bold: true)
+    assert Pdf.Font.HelveticaBoldOblique == Pdf.Font.lookup("Helvetica", bold: true, italic: true)
+    assert Pdf.Font.HelveticaOblique == Pdf.Font.lookup("Helvetica", bold: false, italic: true)
   end
 end

--- a/test/pdf/fonts_test.exs
+++ b/test/pdf/fonts_test.exs
@@ -1,0 +1,75 @@
+defmodule Pdf.FontsTest do
+  use ExUnit.Case
+
+  alias Pdf.Document
+  alias Pdf.Fonts
+  alias Pdf.ExternalFont
+
+  test "looking up an internal font by name" do
+    document = Document.new()
+
+    assert %Fonts.FontReference{module: Pdf.Font.Helvetica} =
+             Fonts.get_font(document.fonts, "Helvetica", [])
+  end
+
+  test "looking up an internal font by font, bold" do
+    document = Document.new()
+
+    assert %Fonts.FontReference{module: Pdf.Font.HelveticaBold} =
+             Fonts.get_font(document.fonts, Pdf.Font.Helvetica, bold: true)
+  end
+
+  test "looking up an internal font by name, bold" do
+    document = Document.new()
+
+    assert %Fonts.FontReference{module: Pdf.Font.HelveticaBold} =
+             Fonts.get_font(document.fonts, "Helvetica", bold: true)
+  end
+
+  test "looking up an internal font by name, italic" do
+    document = Document.new()
+
+    assert %Fonts.FontReference{module: Pdf.Font.HelveticaOblique} =
+             Fonts.get_font(document.fonts, "Helvetica", italic: true)
+  end
+
+  test "looking up an internal font by name, bold, italic" do
+    document = Document.new()
+
+    assert %Fonts.FontReference{module: Pdf.Font.HelveticaBoldOblique} =
+             Fonts.get_font(document.fonts, "Helvetica", italic: true, bold: true)
+  end
+
+  test "cannot look up an internal font by name, that has no variants" do
+    document = Document.new()
+
+    refute Fonts.get_font(document.fonts, "Symbol", bold: true)
+  end
+
+  test "Looking up an external font by name" do
+    document =
+      Document.new()
+      |> Document.add_external_font("test/fonts/Verdana.afm")
+
+    assert %Fonts.FontReference{module: %ExternalFont{name: "Verdana"}} =
+             Fonts.get_font(document.fonts, "Verdana", [])
+  end
+
+  test "Looking up an external font by font, and variant" do
+    document =
+      Document.new()
+      |> Document.add_external_font("test/fonts/Verdana.afm")
+      |> Document.add_external_font("test/fonts/Verdana-Bold.afm")
+
+    assert %Fonts.FontReference{module: %ExternalFont{name: "Verdana-Bold"}} =
+             Fonts.get_font(document.fonts, %ExternalFont{family_name: "Verdana"}, bold: true)
+  end
+
+  test "Looking up an external font by name, and non-existing variant" do
+    document =
+      Document.new()
+      |> Document.add_external_font("test/fonts/Verdana.afm")
+
+    refute Fonts.get_font(document.fonts, %ExternalFont{family_name: "Verdana"}, bold: true)
+  end
+end


### PR DESCRIPTION
I had some issues with using an external font now.
Before the font metrics where a struct inside the fonts, now they are functions.
The `ExternalFont` was no longer compliant with this.
