### PR TITLE
Replace maps with ets

### DIFF
--- a/test/pdf/external_font_test.exs
+++ b/test/pdf/external_font_test.exs
@@ -45,7 +45,7 @@ defmodule Pdf.ExternalFontTest do
   end
 
   test "width/2", %{font: font} do
-    assert 684 == ExternalFont.width(font, "A")
+    assert 684 == ExternalFont.width(font, 65)
   end
 
   describe "text_width/3" do


### PR DESCRIPTION
Hey Andrew,
I was not happy with the performance of the external fonts.
I first tried to write a compiler that would take a font dir and generate the code, as you do.
That worked fine for Verdana, but when I tried with DejaVuSans, a compiler error was generated, the function became too complex. So I revisited this code and replaced the lookups for `kern_text` and `width` with `ets`. A great speed improvement.