### PR TITLE
Limit glyphs

### DIFF
--- a/lib/pdf/external_font.ex
+++ b/lib/pdf/external_font.ex
@@ -17,6 +17,7 @@ defmodule Pdf.ExternalFont do
             fixed_pitch: false,
             bbox: nil,
             widths: [],
+            glyph_widths: %{},
             glyphs: %{},
             kern_pairs: []
 
@@ -63,6 +64,7 @@ defmodule Pdf.ExternalFont do
       fixed_pitch: font_metrics.fixed_pitch,
       bbox: font_metrics.bbox,
       widths: widths,
+      glyph_widths: map_widths(font_metrics),
       glyphs: font_metrics.glyphs,
       kern_pairs: font_metrics.kern_pairs
     }
@@ -110,6 +112,23 @@ defmodule Pdf.ExternalFont do
     byte_size(to_iolist(font) |> Enum.join())
   end
 
+  defp map_widths(font) do
+    Pdf.Encoding.WinAnsi.characters()
+    |> Enum.map(fn {_, char, name} ->
+      width =
+        case font.glyphs[name] do
+          nil ->
+            0
+
+          %{width: width} ->
+            width
+        end
+
+      {char, width}
+    end)
+    |> Map.new()
+  end
+
   @doc """
   Returns the width of the specific character
 
@@ -123,21 +142,7 @@ defmodule Pdf.ExternalFont do
   end
 
   def width(font, char_code) do
-    Pdf.Encoding.WinAnsi.characters()
-    |> Enum.find(fn {_, char, _} -> char == char_code end)
-    |> case do
-      nil ->
-        0
-
-      {_, _, name} ->
-        case font.glyphs[name] do
-          nil ->
-            0
-
-          %{width: width} ->
-            width
-        end
-    end
+    font.glyph_widths[char_code]
   end
 
   def kern_text(_font, ""), do: [""]

--- a/lib/pdf/external_font.ex
+++ b/lib/pdf/external_font.ex
@@ -142,7 +142,7 @@ defmodule Pdf.ExternalFont do
   end
 
   def width(font, char_code) do
-    font.glyph_widths[char_code]
+    font.glyph_widths[char_code] || 0
   end
 
   def kern_text(_font, ""), do: [""]

--- a/lib/pdf/font/metrics.ex
+++ b/lib/pdf/font/metrics.ex
@@ -80,7 +80,12 @@ defmodule Pdf.Font.Metrics do
 
   def process_line(<<"C ", _rest::binary>> = line, %{glyphs: glyphs} = metrics) do
     glyph = parse_glyph(line)
-    %{metrics | glyphs: Map.put(glyphs, glyph.name, glyph)}
+
+    if Pdf.Encoding.WinAnsi.from_name(glyph.name) do
+      %{metrics | glyphs: Map.put(glyphs, glyph.name, glyph)}
+    else
+      metrics
+    end
   end
 
   def process_line(<<"KPX ", data::binary>>, %{kern_pairs: kern_pairs} = metrics) do

--- a/test/pdf/external_font_test.exs
+++ b/test/pdf/external_font_test.exs
@@ -46,6 +46,7 @@ defmodule Pdf.ExternalFontTest do
 
   test "width/2", %{font: font} do
     assert 684 == ExternalFont.width(font, "A")
+    assert 0 == ExternalFont.width(font, "€")
   end
 
   describe "text_width/3" do


### PR DESCRIPTION
Limit loading of glyphs from external fonts to only those used in WinAnsi encoding