### PR TITLE
Add :odd/:even row_style keys that are overridden by index style keys

### DIFF
--- a/lib/pdf/table.ex
+++ b/lib/pdf/table.ex
@@ -168,8 +168,11 @@ defmodule Pdf.Table do
   defp chunk_rows([], _row_index, _page, _opts, _row_opts), do: []
 
   defp chunk_rows([row | rows], row_index, page, opts, row_opts) do
-    row =
-      merge_col_opts(row, Keyword.get(opts, :cols, []), opts, Map.get(row_opts, row_index, []))
+    row_even_odd_style = Map.get(row_opts, if(rem(row_index, 2) == 0, do: :even, else: :odd), [])
+    row_index_style = Map.get(row_opts, row_index, [])
+    row_style = Keyword.merge(row_even_odd_style, row_index_style)
+
+    row = merge_col_opts(row, Keyword.get(opts, :cols, []), opts, row_style)
 
     [chunk_cols(row, page) | chunk_rows(rows, row_index + 1, page, opts, row_opts)]
   end

--- a/test/examples/table_test.exs
+++ b/test/examples/table_test.exs
@@ -30,7 +30,14 @@ defmodule Pdf.Examples.TableTest do
         [width: 80, align: :right, padding: {2, 4}]
       ],
       rows: %{
+        :odd => [
+          background: :yellow
+        ],
+        :even => [
+          background: :pink
+        ],
         0 => [
+          background: :silver,
           bold: true,
           align: :center,
           kerning: true,


### PR DESCRIPTION
Table options can now include a `rows` map with `:odd` and `:even` keys that are lowest priority, i.e. they are overridden by indexed properties

### Example
```elixir
table_opts = [
  rows: %{
    :odd => [background: :yellow],
    :even => [background: :pink],
    13 => [background: :blue]
  }
]
```
Row backgrounds will alternate between yellow and pink but the 13th row will have a blue background.