### PR TITLE
Fix non-win-ansi replacement to handle >1 char

### DIFF
--- a/lib/pdf/encoding/win_ansi.ex
+++ b/lib/pdf/encoding/win_ansi.ex
@@ -300,5 +300,5 @@ defmodule Pdf.Encoding.WinAnsi do
   def encode(_, :raise), do: raise(ArgumentError, "Incompatible with WinAnsi encoding")
 
   def encode(<<_::utf8, rest::binary>>, replace_with) when is_binary(replace_with),
-    do: replace_with <> encode(rest)
+    do: replace_with <> encode(rest, replace_with)
 end


### PR DESCRIPTION
If a non-`:raise` option is passed, it is only applied to the first problem character. Any further characters will still cause an exception to be raised.

Fix it to use the same option in recursive calls.