### PR TITLE
Update typespec

### DIFF
--- a/lib/pdf.ex
+++ b/lib/pdf.ex
@@ -459,7 +459,7 @@ defmodule Pdf do
   `:align` | :left , :center , :right | :left
   `:kerning` | `boolean` | false
   """
-  @spec text_wrap(pid, coords(), dimension(), binary | list, keyword) :: pid
+  @spec text_wrap(pid, coords(), dimension(), binary | list, keyword) :: {pid, :complete | term()}
   defcall text_wrap(coords, dimensions, text, opts, _from, document) do
     {document, remaining} = Document.text_wrap(document, coords, dimensions, text, opts)
     {:reply, {self(), remaining}, document}


### PR DESCRIPTION
The Dialyzer error from https://github.com/andrewtimberlake/elixir-pdf/issues/37 is still there for `text_wrap/5` (with options passed).

This should fix it.