### PR TITLE
Fix warning due to Elixir 1.17

### DIFF
--- a/lib/pdf/font.ex
+++ b/lib/pdf/font.ex
@@ -22,6 +22,7 @@ defmodule Pdf.Font do
 
     defmodule font_module do
       @moduledoc false
+
       @doc "The name of the font"
       def name, do: unquote(metrics.name)
       @doc "The full name of the font"
@@ -161,10 +162,10 @@ defmodule Pdf.Font do
     |> Dictionary.put("Type", n("Font"))
     |> Dictionary.put("Subtype", n("Type1"))
     |> Dictionary.put("Name", n("F#{id}"))
-    |> Dictionary.put("BaseFont", n(font.name))
+    |> Dictionary.put("BaseFont", n(font_field(font, :name)))
     |> Dictionary.put("FirstChar", 32)
-    |> Dictionary.put("LastChar", font.last_char)
-    |> Dictionary.put("Widths", Array.new(Enum.drop(font.widths, 32)))
+    |> Dictionary.put("LastChar", font_field(font, :last_char))
+    |> Dictionary.put("Widths", Array.new(Enum.drop(font_field(font, :widths), 32)))
     |> Dictionary.put("Encoding", n("WinAnsiEncoding"))
   end
 

--- a/lib/pdf/fonts.ex
+++ b/lib/pdf/fonts.ex
@@ -110,7 +110,7 @@ defmodule Pdf.Fonts do
     end
 
     defp lookup_font(state, font, opts) do
-      lookup_font(state, font.family_name, opts)
+      lookup_font(state, font_field(font, :family_name), opts)
     end
 
     defp lookup_font(%{fonts: fonts} = state, name) when is_binary(name) do
@@ -122,7 +122,7 @@ defmodule Pdf.Fonts do
     end
 
     defp lookup_font(%{fonts: fonts} = state, font_module) do
-      case fonts[font_module.name] do
+      case fonts[font_field(font_module, :name)] do
         nil -> load_font(state, font_module)
         font -> {state, font}
       end
@@ -138,7 +138,7 @@ defmodule Pdf.Fonts do
         object: font_object
       }
 
-      fonts = Map.put(fonts, font_module.name, reference)
+      fonts = Map.put(fonts, font_field(font_module, :name), reference)
       {%{state | last_id: id, fonts: fonts}, reference}
     end
   end

--- a/lib/pdf/page.ex
+++ b/lib/pdf/page.ex
@@ -234,7 +234,7 @@ defmodule Pdf.Page do
           if Enum.any?([:bold, :italic], &Keyword.has_key?(opts, &1)) do
             Fonts.get_font(fonts, font, Keyword.take(opts, [:bold, :italic]))
           else
-            Fonts.get_font(fonts, font.name, [])
+            Fonts.get_font(fonts, font_field(font, :name), [])
           end
 
         font_size = Keyword.get(opts, :font_size, page.current_font_size)
@@ -242,10 +242,10 @@ defmodule Pdf.Page do
         color = Keyword.get(opts, :color, page.fill_color)
 
         height = Enum.max([leading, font_size])
-        ascender = font.module.ascender * font_size / 1000
-        descender = -(font.module.descender * font_size / 1000)
-        cap_height = (font.module.cap_height || 0) * font_size / 1000
-        x_height = (font.module.x_height || 0) * font_size / 1000
+        ascender = font_field(font.module, :ascender) * font_size / 1000
+        descender = -(font_field(font.module, :descender) * font_size / 1000)
+        cap_height = (font_field(font.module, :cap_height) || 0) * font_size / 1000
+        x_height = (font_field(font.module, :x_height) || 0) * font_size / 1000
         line_gap = (font_size - (ascender + descender)) / 2
 
         width = Font.text_width(font.module, text, font_size, opts)
@@ -463,11 +463,12 @@ defmodule Pdf.Page do
     attributed_text
     |> merge_same_opts
     |> Enum.reduce(page, fn {text, _width, opts}, page ->
+      module = opts[:font].module
       page
-      |> set_font(opts[:font].module.name, opts[:font_size], opts)
+      |> set_font(font_field(module, :name), opts[:font_size], opts)
       |> set_text_leading(opts[:leading])
       |> set_fill_color(opts[:color])
-      |> push(kerned_text(opts[:font].module, text, opts))
+      |> push(kerned_text(module, text, opts))
     end)
   end
 

--- a/lib/pdf/utils.ex
+++ b/lib/pdf/utils.ex
@@ -16,4 +16,12 @@ defmodule Pdf.Utils do
   @doc false
   def a(%Pdf.Array{} = array), do: array
   def a(list), do: Pdf.Array.new(list)
+
+  def font_field(font, name) do
+    if is_struct(font) do
+      Map.get(font, name)
+    else
+      apply(font, name, [])
+    end
+  end
 end


### PR DESCRIPTION
# Overview
As discussion in #44 that the library needs new implementation because at the run-time, it does not know the font is module or struct, so it raises warning when calling `font.name`. This is fix for warning due to Elixir 1.17 for current implementation.