### PR TITLE
Font refactor

### DIFF
--- a/lib/pdf/external_font.ex
+++ b/lib/pdf/external_font.ex
@@ -1,5 +1,6 @@
 defmodule Pdf.ExternalFont do
   @moduledoc false
+  @derive {Inspect, only: [:name, :family_name, :weight, :italic_angle]}
   defstruct name: nil,
             font_file: nil,
             dictionary: nil,
@@ -49,8 +50,6 @@ defmodule Pdf.ExternalFont do
 
     %__MODULE__{
       name: font_metrics.name,
-      font_file: font_file,
-      dictionary: font_file_dictionary(part1, part2, part3),
       full_name: font_metrics.full_name,
       family_name: font_metrics.family_name,
       weight: font_metrics.weight,
@@ -65,9 +64,11 @@ defmodule Pdf.ExternalFont do
       fixed_pitch: font_metrics.fixed_pitch,
       bbox: font_metrics.bbox,
       widths: widths,
-      glyph_widths: map_widths(font_metrics),
+      glyph_widths: Metrics.map_widths(font_metrics),
       glyphs: font_metrics.glyphs,
-      kern_pairs: font_metrics.kern_pairs
+      kern_pairs: font_metrics.kern_pairs,
+      font_file: font_file,
+      dictionary: font_file_dictionary(part1, part2, part3)
     }
   end
 
@@ -111,23 +112,6 @@ defmodule Pdf.ExternalFont do
   def size(%__MODULE__{} = font) do
     # size_of(font.dictionary) + byte_size(font.font_file) + byte_size(@stream_start <> @stream_end)
     byte_size(to_iolist(font) |> Enum.join())
-  end
-
-  defp map_widths(font) do
-    Pdf.Encoding.WinAnsi.characters()
-    |> Enum.map(fn {_, char, name} ->
-      width =
-        case font.glyphs[name] do
-          nil ->
-            0
-
-          %{width: width} ->
-            width
-        end
-
-      {char, width}
-    end)
-    |> Map.new()
   end
 
   @doc """

--- a/lib/pdf/font/metrics.ex
+++ b/lib/pdf/font/metrics.ex
@@ -36,6 +36,23 @@ defmodule Pdf.Font.Metrics do
     end)
   end
 
+  def map_widths(font) do
+    Pdf.Encoding.WinAnsi.characters()
+    |> Enum.map(fn {_, char, name} ->
+      width =
+        case font.glyphs[name] do
+          nil ->
+            0
+
+          %{width: width} ->
+            width
+        end
+
+      {char, width}
+    end)
+    |> Map.new()
+  end
+
   def process_line(<<"FontName ", data::binary>>, metrics), do: %{metrics | name: data}
   def process_line(<<"FullName ", data::binary>>, metrics), do: %{metrics | full_name: data}
   def process_line(<<"FamilyName ", data::binary>>, metrics), do: %{metrics | family_name: data}

--- a/lib/pdf/page.ex
+++ b/lib/pdf/page.ex
@@ -541,8 +541,8 @@ defmodule Pdf.Page do
 
   defp kern_text(text, font, true) do
     text =
-      text
-      |> font.kern_text()
+      font
+      |> Font.kern_text(text)
       |> Text.escape()
       |> Enum.map(fn
         str when is_binary(str) -> s(str)

--- a/test/pdf/font_test.exs
+++ b/test/pdf/font_test.exs
@@ -1,10 +1,12 @@
 defmodule Pdf.FontTest do
   use ExUnit.Case, async: true
+
   alias Pdf.Font
+  alias Pdf.Fonts
 
   describe "text_width/3" do
     test "It calculates the width of a line of text" do
-      font = Pdf.Font.Helvetica
+      font = Fonts.get_internal_font("Helvetica")
       assert Font.text_width(font, "VA") == 1334
       assert Font.text_width(font, "VA", 10) == 13.34
       assert Font.text_width(font, "VA", kerning: true) == 1254
@@ -15,18 +17,11 @@ defmodule Pdf.FontTest do
     end
 
     test "It calculates the width of a blank string" do
-      font = Pdf.Font.Helvetica
+      font = Fonts.get_internal_font("Helvetica")
       assert Font.text_width(font, "") == 0
       assert Font.text_width(font, "", 10) == 0
       assert Font.text_width(font, "", kerning: true) == 0
       assert Font.text_width(font, "", 10, kerning: true) == 0
     end
-  end
-
-  describe "lookup" do
-    assert Pdf.Font.Helvetica == Pdf.Font.lookup("Helvetica")
-    assert Pdf.Font.HelveticaBold == Pdf.Font.lookup("Helvetica", bold: true)
-    assert Pdf.Font.HelveticaBoldOblique == Pdf.Font.lookup("Helvetica", bold: true, italic: true)
-    assert Pdf.Font.HelveticaOblique == Pdf.Font.lookup("Helvetica", bold: false, italic: true)
   end
 end

--- a/test/pdf/fonts_test.exs
+++ b/test/pdf/fonts_test.exs
@@ -8,35 +8,28 @@ defmodule Pdf.FontsTest do
   test "looking up an internal font by name" do
     document = Document.new()
 
-    assert %Fonts.FontReference{module: Pdf.Font.Helvetica} =
+    assert %Fonts.FontReference{module: %Pdf.Font{name: "Helvetica"}} =
              Fonts.get_font(document.fonts, "Helvetica", [])
-  end
-
-  test "looking up an internal font by font, bold" do
-    document = Document.new()
-
-    assert %Fonts.FontReference{module: Pdf.Font.HelveticaBold} =
-             Fonts.get_font(document.fonts, Pdf.Font.Helvetica, bold: true)
   end
 
   test "looking up an internal font by name, bold" do
     document = Document.new()
 
-    assert %Fonts.FontReference{module: Pdf.Font.HelveticaBold} =
+    assert %Fonts.FontReference{module: %Pdf.Font{name: "Helvetica-Bold"}} =
              Fonts.get_font(document.fonts, "Helvetica", bold: true)
   end
 
   test "looking up an internal font by name, italic" do
     document = Document.new()
 
-    assert %Fonts.FontReference{module: Pdf.Font.HelveticaOblique} =
+    assert %Fonts.FontReference{module: %Pdf.Font{name: "Helvetica-Oblique"}} =
              Fonts.get_font(document.fonts, "Helvetica", italic: true)
   end
 
   test "looking up an internal font by name, bold, italic" do
     document = Document.new()
 
-    assert %Fonts.FontReference{module: Pdf.Font.HelveticaBoldOblique} =
+    assert %Fonts.FontReference{module: %Pdf.Font{name: "Helvetica-BoldOblique"}} =
              Fonts.get_font(document.fonts, "Helvetica", italic: true, bold: true)
   end
 

--- a/test/pdf/text_test.exs
+++ b/test/pdf/text_test.exs
@@ -4,7 +4,7 @@ defmodule Pdf.TextTest do
   alias Pdf.Text
 
   setup do
-    font = Pdf.Font.Helvetica
+    font = Pdf.Fonts.get_internal_font("Helvetica")
     font_size = 10
     {:ok, font: font, font_size: font_size}
   end


### PR DESCRIPTION
Fonts are no longer named modules but instances of the Font struct.
This is now the same as how ExternalFont works.